### PR TITLE
refactor: Update line annotation logic for line ending styles

### DIFF
--- a/src/annotations/line_annotation.ts
+++ b/src/annotations/line_annotation.ts
@@ -48,13 +48,15 @@ export class LineAnnotationObj
       ret.push(WriterUtil.SPACE);
     }
 
-    if (this.lineEndingStyles && this.lineEndingStyles.length >= 2) {
+    if (this.lineEndingStyles && this.lineEndingStyles.length >= 1) {
       ret = ret.concat(WriterUtil.LINE_ENDING);
       ret.push(WriterUtil.ARRAY_START);
       ret.push(WriterUtil.SPACE);
       ret = ret.concat(this.convertLineEndingStyle(this.lineEndingStyles[0]));
-      ret.push(WriterUtil.SPACE);
-      ret = ret.concat(this.convertLineEndingStyle(this.lineEndingStyles[1]));
+      if (this.lineEndingStyles.length === 2) {
+        ret.push(WriterUtil.SPACE);
+        ret = ret.concat(this.convertLineEndingStyle(this.lineEndingStyles[1]));
+      }
       ret.push(WriterUtil.SPACE);
       ret.push(WriterUtil.ARRAY_END);
       ret.push(WriterUtil.SPACE);


### PR DESCRIPTION
Simplify the logic for handling line ending styles in the LineAnnotationObj class. Previously, the code checked if the lineEndingStyles array had at least 2 elements before processing the second element. Now, it only checks if the array has at least 1 element. This change improves code readability and reduces unnecessary checks.